### PR TITLE
TST: Fix dict tests to run in separate directories

### DIFF
--- a/pythagoras/tests/test_dicts_full.py
+++ b/pythagoras/tests/test_dicts_full.py
@@ -13,26 +13,32 @@ MUTABLE_DICT_PARAMS = [
 ]
 
 
-# TODO: Implement as contextmanager
-def mkdicts(dicts_params):
-    tmpdirs = []
-    dicts = []
-    for dict_type, dict_params in dicts_params:
-        _dict_params = {}
+
+class DictGenerator():
+    def __init__(self, dicts_params):
+        self.dicts_params = dicts_params
+        self.tmpdirs = []
+
+    def __enter__(self):
+        return [
+            self._gen_dict(dict_type, dict_params)
+            for dict_type, dict_params in self.dicts_params
+        ]
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        for tmpdir in self.tmpdirs:
+            tmpdir.cleanup()
+
+    def _gen_dict(self, dict_type, dict_params):
+        new_params = {}
         for key, value in dict_params.items():
-            _dict_params = dict_params.copy()
             if value == "__TMPDIR__":
-                _tmpdir = TemporaryDirectory()
-                _dict_params[key] = _tmpdir.name
+                tmpdir = TemporaryDirectory(prefix='dictgen')
+                self.tmpdirs.append(tmpdir)
+                new_params[key] = tmpdir.name
             else:
-                _dict_params[key] = value
-        new_dict = dict_type(**dict_params)
-        new_dict.clear()
-        dicts.append(new_dict)
-    yield dicts
-    for tmpdir in tmpdirs:
-        tmpdir.cleanup()
-    yield
+                new_params[key] = value
+        return dict_type(**new_params)
 
 
 # TODO: Try to set values of various types
@@ -42,19 +48,17 @@ def test_set_random_values(random_pairs, dicts_params):
     """
     Write random values into the dict and ensure that it correctly stores them
     """
-    dict_gen = mkdicts(dicts_params)
-    dicts_to_test = next(dict_gen)
-    for dict_to_test in dicts_to_test:
-        model_dict = dict()
-        assert dict_to_test == model_dict
-        for key, value in random_pairs:
-            dict_to_test[key] = value
-            model_dict[key] = value
-            assert key in dict_to_test
+    with DictGenerator(dicts_params) as dicts_to_test:
+        for dict_to_test in dicts_to_test:
+            model_dict = dict()
+            assert dict_to_test == model_dict
+            for key, value in random_pairs:
+                dict_to_test[key] = value
+                model_dict[key] = value
+                assert key in dict_to_test
 
-        assert len(dict_to_test) == len(model_dict)
-        assert dict_to_test == model_dict
-    next(dict_gen)
+            assert len(dict_to_test) == len(model_dict)
+            assert dict_to_test == model_dict
 
 
 @pytest.mark.parametrize("dicts_params", [MUTABLE_DICT_PARAMS])
@@ -63,20 +67,18 @@ def test_set_del(random_pair, dicts_params):
     """
     Ensure that deleting items from dict works
     """
-    dict_gen = mkdicts(dicts_params)
-    dicts_to_test = next(dict_gen)
-    for dict_to_test in dicts_to_test:
-        key, value = random_pair
+    with DictGenerator(dicts_params) as dicts_to_test:
+        for dict_to_test in dicts_to_test:
+            key, value = random_pair
 
-        with pytest.raises(KeyError):
+            with pytest.raises(KeyError):
+                del dict_to_test[key]
+
+            dict_to_test[key] = value
+            assert key in dict_to_test
+
             del dict_to_test[key]
-
-        dict_to_test[key] = value
-        assert key in dict_to_test
-
-        del dict_to_test[key]
-        assert key not in dict_to_test
-    next(dict_gen)
+            assert key not in dict_to_test
 
 
 @pytest.mark.parametrize("dicts_params", [MUTABLE_DICT_PARAMS])
@@ -85,18 +87,16 @@ def test_get(random_pair, random_value, dicts_params):
     """
     Ensure that .get()tting items from dict works as expected
     """
-    dict_gen = mkdicts(dicts_params)
-    dicts_to_test = next(dict_gen)
-    for dict_to_test in dicts_to_test:
-        key, init_value = random_pair
+    with DictGenerator(dicts_params) as dicts_to_test:
+        for dict_to_test in dicts_to_test:
+            key, init_value = random_pair
 
-        get_value = dict_to_test.get(key, init_value)
-        assert get_value == init_value
+            get_value = dict_to_test.get(key, init_value)
+            assert get_value == init_value
 
-        dict_to_test[key] = random_value
-        get_value = dict_to_test.get(key, init_value)
-        assert get_value == random_value
-    next(dict_gen)
+            dict_to_test[key] = random_value
+            get_value = dict_to_test.get(key, init_value)
+            assert get_value == random_value
 
 
 @pytest.mark.parametrize("dicts_params", [MUTABLE_DICT_PARAMS])
@@ -105,14 +105,12 @@ def test_setdefault(random_pair, dicts_params):
     """
     Ensure that .setdefault() works as expected
     """
-    dict_gen = mkdicts(dicts_params)
-    dicts_to_test = next(dict_gen)
-    for dict_to_test in dicts_to_test:
-        key, value = random_pair
+    with DictGenerator(dicts_params) as dicts_to_test:
+        for dict_to_test in dicts_to_test:
+            key, value = random_pair
 
-        assert dict_to_test.setdefault(key, value) == value
-        assert key in dict_to_test
-    next(dict_gen)
+            assert dict_to_test.setdefault(key, value) == value
+            assert key in dict_to_test
 
 
 @pytest.mark.parametrize("dicts_params", [MUTABLE_DICT_PARAMS])
@@ -121,14 +119,12 @@ def test_pop(random_pair, dicts_params):
     """
     Ensure that .pop()ping items from dict works as expected
     """
-    dict_gen = mkdicts(dicts_params)
-    dicts_to_test = next(dict_gen)
-    for dict_to_test in dicts_to_test:
-        key, value = random_pair
+    with DictGenerator(dicts_params) as dicts_to_test:
+        for dict_to_test in dicts_to_test:
+            key, value = random_pair
 
-        dict_to_test[key] = value
-        pop_value = dict_to_test.pop(key, value)
-        assert pop_value == value
+            dict_to_test[key] = value
+            pop_value = dict_to_test.pop(key, value)
+            assert pop_value == value
 
-        assert key not in dict_to_test
-    next(dict_gen)
+            assert key not in dict_to_test


### PR DESCRIPTION
Contextmanager is employed to generate dicts replacing a generator